### PR TITLE
after_filter is no longer used in Rails 6+

### DIFF
--- a/lib/generators/easy_captcha/install_generator.rb
+++ b/lib/generators/easy_captcha/install_generator.rb
@@ -17,7 +17,7 @@ module EasyCaptcha
 
       def add_after_filter #:nodoc:
         inject_into_class 'app/controllers/application_controller.rb', ApplicationController do
-          "  # reset captcha code after each request for security\n  after_filter :reset_last_captcha_code!\n\n"
+          "  # reset captcha code after each request for security\n  after_action :reset_last_captcha_code!\n\n"
         end
       end
     end


### PR DESCRIPTION
I replaced after_filter by after_action
As is, after_filter generates a critical error in Rails 6+.